### PR TITLE
Add rules to enforcing casing of Operation Tags

### DIFF
--- a/_rules/openapi-v3-operations-operation-ids-pascal-case.md
+++ b/_rules/openapi-v3-operations-operation-ids-pascal-case.md
@@ -1,5 +1,5 @@
 ---
-oopenapi-v3-perations-operation-ids-pascal-case:
+openapi-v3-operations-operation-ids-pascal-case:
   description: Ensures that each of the operations IDs are pascal case.
   message: Your operations IDs need to be pascal case.
   given: $.paths.*[get,post,patch,put,delete].operationId
@@ -10,7 +10,7 @@ oopenapi-v3-perations-operation-ids-pascal-case:
       type: pascal
   type: style
 ...
-oopenapi-v3-perations-operation-ids-pascal-case:
+openapi-v3-operations-operation-ids-pascal-case:
   description: Ensures that each of the operations IDs are pascal case.
   message: Your operations IDs need to be pascal case.
   given: $.paths.*[get,post,patch,put,delete].operationId

--- a/_rules/openapi-v3-operations-tags-camel-case.md
+++ b/_rules/openapi-v3-operations-tags-camel-case.md
@@ -1,0 +1,13 @@
+openapi-v3-operations-tags-camel-case:
+    description: Ensures that each of the operation tags are camelCase.
+    message: Your operation tag "{{value}}" SHOULD be camelCase.
+    severity: warn
+    formats:
+      - oas3
+    given: $.paths.*[get,post,patch,put,delete].tags[*]
+    recommended: true
+    then:
+      function: casing
+      functionOptions:
+        type: camel
+    type: style

--- a/_rules/openapi-v3-operations-tags-camel-case.md
+++ b/_rules/openapi-v3-operations-tags-camel-case.md
@@ -1,3 +1,18 @@
+---
+openapi-v3-operations-tags-camel-case:
+    description: Ensures that each of the operation tags are camelCase.
+    message: Your operation tag "{{value}}" SHOULD be camelCase.
+    severity: warn
+    formats:
+      - oas3
+    given: $.paths.*[get,post,patch,put,delete].tags[*]
+    recommended: true
+    then:
+      function: casing
+      functionOptions:
+        type: camel
+    type: style
+...
 openapi-v3-operations-tags-camel-case:
     description: Ensures that each of the operation tags are camelCase.
     message: Your operation tag "{{value}}" SHOULD be camelCase.

--- a/_rules/openapi-v3-operations-tags-kebab-case.md
+++ b/_rules/openapi-v3-operations-tags-kebab-case.md
@@ -1,0 +1,13 @@
+openapi-v3-operations-tags-kebab-case:
+    description: Ensures that each of the operation tags are kebab-case.
+    message: Your operation tag "{{value}}" SHOULD be kebab-case.
+    severity: warn
+    formats:
+      - oas3
+    given: $.paths.*[get,post,patch,put,delete].tags[*]
+    recommended: true
+    then:
+      function: casing
+      functionOptions:
+        type: kebab
+    type: style

--- a/_rules/openapi-v3-operations-tags-kebab-case.md
+++ b/_rules/openapi-v3-operations-tags-kebab-case.md
@@ -1,3 +1,4 @@
+---
 openapi-v3-operations-tags-kebab-case:
     description: Ensures that each of the operation tags are kebab-case.
     message: Your operation tag "{{value}}" SHOULD be kebab-case.
@@ -11,3 +12,18 @@ openapi-v3-operations-tags-kebab-case:
       functionOptions:
         type: kebab
     type: style
+...
+openapi-v3-operations-tags-kebab-case:
+    description: Ensures that each of the operation tags are kebab-case.
+    message: Your operation tag "{{value}}" SHOULD be kebab-case.
+    severity: warn
+    formats:
+      - oas3
+    given: $.paths.*[get,post,patch,put,delete].tags[*]
+    recommended: true
+    then:
+      function: casing
+      functionOptions:
+        type: kebab
+    type: style
+

--- a/_rules/openapi-v3-operations-tags-pascal-case.md
+++ b/_rules/openapi-v3-operations-tags-pascal-case.md
@@ -1,3 +1,18 @@
+---
+openapi-v3-operations-tags-pascal-case:
+    description: Ensures that each of the operation tags are PascalCase.
+    message: Your operation tag "{{value}}" SHOULD be PascalCase.
+    severity: warn
+    formats:
+      - oas3
+    given: $.paths.*[get,post,patch,put,delete].tags[*]
+    recommended: true
+    then:
+      function: casing
+      functionOptions:
+        type: pascal
+    type: style
+...
 openapi-v3-operations-tags-pascal-case:
     description: Ensures that each of the operation tags are PascalCase.
     message: Your operation tag "{{value}}" SHOULD be PascalCase.

--- a/_rules/openapi-v3-operations-tags-pascal-case.md
+++ b/_rules/openapi-v3-operations-tags-pascal-case.md
@@ -1,0 +1,13 @@
+openapi-v3-operations-tags-pascal-case:
+    description: Ensures that each of the operation tags are PascalCase.
+    message: Your operation tag "{{value}}" SHOULD be PascalCase.
+    severity: warn
+    formats:
+      - oas3
+    given: $.paths.*[get,post,patch,put,delete].tags[*]
+    recommended: true
+    then:
+      function: casing
+      functionOptions:
+        type: pascal
+    type: style

--- a/_rules/openapi-v3-operations-tags-snake-case.md
+++ b/_rules/openapi-v3-operations-tags-snake-case.md
@@ -1,0 +1,13 @@
+openapi-v3-operations-tags-snake-case:
+    description: Ensures that each of the operation tags are snake-case.
+    message: Your operation tag "{{value}}" SHOULD be snake-case.
+    severity: warn
+    formats:
+      - oas3
+    given: $.paths.*[get,post,patch,put,delete].tags[*]
+    recommended: true
+    then:
+      function: casing
+      functionOptions:
+        type: snake
+    type: style

--- a/_rules/openapi-v3-operations-tags-snake-case.md
+++ b/_rules/openapi-v3-operations-tags-snake-case.md
@@ -1,4 +1,19 @@
+--- 
 openapi-v3-operations-tags-snake-case:
+    description: Ensures that each of the operation tags are snake_case.
+    message: Your operation tag "{{value}}" SHOULD be snake_case.
+    severity: warn
+    formats:
+      - oas3
+    given: $.paths.*[get,post,patch,put,delete].tags[*]
+    recommended: true
+    then:
+      function: casing
+      functionOptions:
+        type: snake
+    type: style
+...
+    openapi-v3-operations-tags-snake-case:
     description: Ensures that each of the operation tags are snake_case.
     message: Your operation tag "{{value}}" SHOULD be snake_case.
     severity: warn

--- a/_rules/openapi-v3-operations-tags-snake-case.md
+++ b/_rules/openapi-v3-operations-tags-snake-case.md
@@ -1,6 +1,6 @@
 openapi-v3-operations-tags-snake-case:
-    description: Ensures that each of the operation tags are snake-case.
-    message: Your operation tag "{{value}}" SHOULD be snake-case.
+    description: Ensures that each of the operation tags are snake_case.
+    message: Your operation tag "{{value}}" SHOULD be snake_case.
     severity: warn
     formats:
       - oas3


### PR DESCRIPTION
I added four new rules for enforcing operation tags casing
- PascalCase
- snake_case
- camelCase
- kebab-case

I also fixed a typo on `openapi-v3-operations-ids-pascal-case` title 